### PR TITLE
fix: create a CNAME file to avoid domain reset

### DIFF
--- a/public/CNAME
+++ b/public/CNAME
@@ -1,0 +1,1 @@
+www.codevolvelabs.com.br


### PR DESCRIPTION
### What I did

- Created a `CNAME` file in `public` folder to avoid domain reset when publishing the website to GitHub Pages.